### PR TITLE
rpmb_emul: write operation result BEFORE calculating MAC

### DIFF
--- a/drivers/tee/optee/rpmb_emul.c
+++ b/drivers/tee/optee/rpmb_emul.c
@@ -309,6 +309,7 @@ static void emu_read_ctr(struct rpmb_emu *mem,
 	debug("Reading counter");
 	frm->msg_type = htons(RPMB_MSG_TYPE_RESP_WRITE_COUNTER_VAL_READ);
 	frm->write_counter = htonl(mem->write_counter);
+	frm->op_result = gen_msb1st_result(RPMB_RESULT_OK);
 	memcpy(frm->nonce, mem->nonce, 16);
 	frm->op_result = compute_hmac(mem, frm, 1);
 }


### PR DESCRIPTION
Apparently original RPM emulator contained a bug, where it updated
frm->op_result with compute_hmac() operation, which is incorrect, as
compute_hmac() takes into account value of frm->op_result too.

We need to set frm->op_result to zero before calculation MAC.

Signed-off-by: Volodymyr Babchuk <volodymyr_babchuk@epam.com>

