### PR TITLE
HACK:Fix Xen shared info page operations for xenguest

### DIFF
--- a/board/xen/xenguest_arm64/xenguest_arm64.c
+++ b/board/xen/xenguest_arm64/xenguest_arm64.c
@@ -96,7 +96,7 @@ static int setup_mem_map(void)
 
 	xen_mem_map[i].virt = PFN_PHYS(gfn);
 	xen_mem_map[i].phys = PFN_PHYS(gfn);
-	xen_mem_map[i].size = PAGE_SIZE;
+	xen_mem_map[i].size = PAGE_SIZE*4;
 	xen_mem_map[i].attrs = (PTE_BLOCK_MEMTYPE(MT_NORMAL) |
 				PTE_BLOCK_INNER_SHARE);
 	i++;

--- a/drivers/xen/hypervisor.c
+++ b/drivers/xen/hypervisor.c
@@ -51,8 +51,9 @@ int in_callback;
 /*
  * Shared page for communicating with the hypervisor.
  * Events flags go here, for example.
+ * The 0x39004000 is address for next page after Xen GUEST_MAGIC region
  */
-struct shared_info *HYPERVISOR_shared_info;
+struct shared_info *HYPERVISOR_shared_info = (struct shared_info*)0x39004000;
 
 #ifndef CONFIG_PARAVIRT
 static const char *param_name(int op)
@@ -147,11 +148,6 @@ int hvm_set_parameter(int idx, uint64_t value)
 struct shared_info *map_shared_info(void *p)
 {
 	struct xen_add_to_physmap xatp;
-
-	HYPERVISOR_shared_info = (struct shared_info *)memalign(PAGE_SIZE,
-								PAGE_SIZE);
-	if (HYPERVISOR_shared_info == NULL)
-		BUG();
 
 	xatp.domid = DOMID_SELF;
 	xatp.idx = 0;
@@ -286,4 +282,5 @@ void xen_fini(void)
 	fini_gnttab();
 	fini_xenbus();
 	fini_events();
+	unmap_shared_info();
 }


### PR DESCRIPTION
The u-boot Xen guest implementation allocates one memory
page from domain RAM address space to map special
Xen shared info page. I.e. it uses hypercall XENMEM_add_to_physmap
with page at some address(X_ADDR) and type HYPERVISOR_shared_info.
This approach leads to a forever mapped Xen shared info page to
some address (X_ADDR) in domain address space, even after u-boot
passes execution to Linux kernel. At the same time, Linux kernel
performs the same operation to obtain Xen shared info page on
some address (X_ADDR2), and it doesn't know anything about X_ADDR,
so any process may allocate memory to valid domain address X_ADDR
and fill it with some data which reflects on reading X_ADDR2.
At some point, some part of the  Android initramfs appeared
on X_ADDR, which led to an extra 10 min boot delay(due to
corruption of the Xen shared info page). Unfortunately, Xen
doesn't provide an API to correct unmap that page. We could use
only hypercall XENMEM_remove_from_physmap which eventually will
create a hole in domain RAM address space. And if Linux kernel
will try to map/use it - data abort appears. This HACK will increase
and use(0x39004000) the special GUEST_MAGIC memory region(which
not included in domain RAM address space). Further xenguest will
use XENMEM_remove_from_physmap to unmap (0x39004000) from  Xen
shared info page. Since it is not in the domain RAM address space,
Linux kernel will not reuse it further(and data corruption will not happen).

Reviewed-by: Volodymyr Babchuk <volodymyr_babchuk@epam.com>
Signed-off-by: Andrii Chepurnyi <andrii_chepurnyi@epam.com>

Please do not submit a Pull Request via github.  Our project makes use of
mailing lists for patch submission and review.  For more details please
see https://www.denx.de/wiki/U-Boot/Patches
