### PR TITLE
xenguest_android: Increase memory length for bootm

### DIFF
--- a/include/configs/xenguest_arm64_android.h
+++ b/include/configs/xenguest_arm64_android.h
@@ -8,7 +8,7 @@
 
 #include <configs/xenguest_arm64.h>
 
-#define CONFIG_SYS_BOOTM_LEN	      (20 * 1024 * 1024)
+#define CONFIG_SYS_BOOTM_LEN	      (30 * 1024 * 1024)
 
 #undef CONFIG_EXTRA_ENV_SETTINGS
 


### PR DESCRIPTION
Increase memory length for bootm command, to be able
boot from Linux kernel 5.4.

Signed-off-by: Andrii Chepurnyi <andrii_chepurnyi@epam.com>

Please do not submit a Pull Request via github.  Our project makes use of
mailing lists for patch submission and review.  For more details please
see https://www.denx.de/wiki/U-Boot/Patches
