### PR TITLE
defconfig: Remove BOOTARGS from rcar defconfigs

### DIFF
--- a/configs/rcar3_xen_defconfig
+++ b/configs/rcar3_xen_defconfig
@@ -17,8 +17,6 @@ CONFIG_SYS_BOOT_GET_CMDLINE=y
 CONFIG_SYS_BARGSIZE=1024
 CONFIG_SUPPORT_RAW_INITRD=y
 CONFIG_OF_SYSTEM_SETUP=y
-CONFIG_USE_BOOTARGS=y
-CONFIG_BOOTARGS="root=/dev/mmcblk1p4 ro rootwait console=hvc0 clk_ignore_unused pci=pcie_bus_perf vardir.disk=/dev/mmcblk1p5 opendisk.target=/dev/mmcblk1p6 opendisk.pkcs11=optee aosupdate.disk=/dev/aosvg/workdirs aosupdate.path=um/update_rootfs aosupdate.selinux_module=/usr/share/selinux/aos/base.pp"
 CONFIG_USE_BOOTCOMMAND=y
 CONFIG_BOOTCOMMAND="ext4load mmc 1:1 0x44001000 linux-domd; ext4load mmc 1:1 0x81000000 initramfs-domd; booti 0x44001000 0x81000000:0x${filesize} 0x48000000"
 CONFIG_HUSH_PARSER=y

--- a/configs/rcar4_xen_defconfig
+++ b/configs/rcar4_xen_defconfig
@@ -17,8 +17,6 @@ CONFIG_SYS_BOOT_GET_CMDLINE=y
 CONFIG_SYS_BARGSIZE=1024
 CONFIG_SUPPORT_RAW_INITRD=y
 CONFIG_OF_SYSTEM_SETUP=y
-CONFIG_USE_BOOTARGS=y
-CONFIG_BOOTARGS="root=/dev/sda4 ro rootwait console=hvc0 clk_ignore_unused pci=pcie_bus_perf vardir.disk=/dev/sda5 opendisk.target=/dev/sda6 opendisk.pkcs11=optee aosupdate.disk=/dev/aosvg/workdirs aosupdate.path=um/update_rootfs aosupdate.selinux_module=/usr/share/selinux/aos/base.pp"
 CONFIG_USE_BOOTCOMMAND=y
 CONFIG_BOOTCOMMAND="scsi scan; ext4load scsi 0:1 0x44001000 linux-domd; ext4load scsi 0:1 0x60000000 initramfs-domd; booti 0x44001000 0x60000000:0x${filesize} 0x48000000"
 CONFIG_HUSH_PARSER=y


### PR DESCRIPTION
It is better to store domain bootargs in the domain config, so remove them from the defconfigs.