### PR TITLE
Fix PCI init sequence to handle more then one PCI device in the system

### DIFF
--- a/drivers/pci/pcie_brcmstb.c
+++ b/drivers/pci/pcie_brcmstb.c
@@ -202,6 +202,7 @@ struct brcm_pcie {
 	struct reset_ctl	rescal;
 	struct reset_ctl	bridge_reset;
 	const struct brcm_pcie_cfg_data *pcie_cfg;
+	uint16_t		bus_base;
 };
 
 /**
@@ -313,6 +314,7 @@ static int brcm_pcie_config_address(const struct udevice *dev, pci_dev_t bdf,
 	 * Busses 0 (host PCIe bridge) and 1 (its immediate child)
 	 * are limited to a single device each
 	 */
+	pci_bus -= pcie->bus_base;
 	if (pci_bus < 2 && pci_dev > 0)
 		return -EINVAL;
 
@@ -630,6 +632,8 @@ static int brcm_pcie_probe(struct udevice *dev)
 	int i, ret;
 	u16 nlw, cls, lnksta;
 	u32 tmp;
+
+	pcie->bus_base = hose->first_busno;
 
 	/*
 	 * Deassert rescal reset for BCM2712.

--- a/drivers/pci/pcie_brcmstb.c
+++ b/drivers/pci/pcie_brcmstb.c
@@ -851,6 +851,16 @@ static int brcm_pcie_remove(struct udevice *dev)
 	/* Shutdown bridge */
 	pcie->pcie_cfg->bridge_sw_init_set(pcie, 1);
 
+	/*
+	 * For the controllers that are utilizing reset for bridge Sw init,
+	 * such as BCM2712, reset should be deasserted after assertion.
+	 * Leaving it in asserted state may lead to unexpected hangs in
+	 * the Linux Kernel driver because it do not perform reset initialization
+	 * and start accessing device memory.
+	 */
+	if (pcie->pcie_cfg->type == BCM2712)
+		pcie->pcie_cfg->bridge_sw_init_set(pcie, 0);
+
 	return 0;
 }
 


### PR DESCRIPTION
When NVME device is attached to RPI5 - another PCI device become active in the device tree.
Provided patches are solving the following problems: 
1) Fix PCI bus numbers to handle child devices properly
2) Set reset to the correct state as expected by the Linux Kernel driver.
